### PR TITLE
Fix prerender spa cannot render route error

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "sass-loader": "10.2.0",
     "swiper": "^6.8.1",
     "vue": "^3.0.0",
-    "vue-meta": "^2.4.0",
     "vue-router": "^4.0.0-0"
   },
   "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -80,9 +80,6 @@ export default {
     TourismIcon,
     BackToTop,
   },
-  mounted() {
-    document.dispatchEvent(new Event("render-event"));
-  },
   setup() {
     const navbarItems = [
       { id: 0, path: "/", title: "首頁" },
@@ -97,6 +94,7 @@ export default {
     const isOpenNavbar = ref(false);
 
     onMounted(() => {
+      document.dispatchEvent(new Event("render-event"));
       navbarRef.value = document.getElementsByClassName("nav-links")[0];
     });
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,5 @@
-import { createApp, use } from 'vue'
+import { createApp } from 'vue'
 import App from './App.vue'
-import Meta from 'vue-meta'
 import router from './router'
 import './styles/styles.css'
 
@@ -11,5 +10,7 @@ import 'swiper/components/navigation/navigation.min.css'
 import SwiperCore, {EffectFade, Navigation, Pagination} from 'swiper/core';
 
 SwiperCore.use([EffectFade, Navigation, Pagination]);
-use(Meta)
-createApp(App).use(router).mount('#app')
+
+createApp(App)
+  .use(router)
+  .mount('#app')

--- a/vue.config.js
+++ b/vue.config.js
@@ -9,7 +9,7 @@ module.exports = {
       config.plugins.push(
         new PrerenderSPAPlugin({
           staticDir: path.join(__dirname, 'dist'),
-          routes: ['/', '/about', '/rooms', '/reservation', '/transportation', 'tourism'],
+          routes: ['/', '/about', '/rooms', '/reservation', '/transportation', '/tourism'],
           renderer: new Renderer({
             renderAfterDocumentEvent: 'render-event',
           }),

--- a/vue.config.js
+++ b/vue.config.js
@@ -2,16 +2,45 @@ const path = require('path');
 const PrerenderSPAPlugin = require('prerender-spa-plugin');
 const Renderer = PrerenderSPAPlugin.PuppeteerRenderer;
 
+const renderRoutes = (() => {
+  const routes = [
+    '/', '/about', '/rooms', '/reservation', '/transportation', '/tourism',
+  ].map((route) => route.replace(/\/$/, ''))
+  routes.push(...routes.map((route) => `${route}/`))
+  return routes
+})()
+
 module.exports = {
   publicPath: '/',
   configureWebpack: (config) => {
+    config.optimization = {
+      splitChunks: {
+        minSize: 10000,
+        maxSize: 200000,
+      }
+    }
+    config.performance = {
+      maxAssetSize: 300000,
+      maxEntrypointSize: 500000,
+    }
     if (process.env.NODE_ENV === 'production') {
       config.plugins.push(
         new PrerenderSPAPlugin({
+          useRenderEvent: true,
+          onlyProduction: true,
+          registry: undefined,
           staticDir: path.join(__dirname, 'dist'),
-          routes: ['/', '/about', '/rooms', '/reservation', '/transportation', '/tourism'],
+          routes: renderRoutes,
+          postProcess(renderedRoute) {
+            renderedRoute.route = renderedRoute.originalRoute
+            if (renderedRoute.route.endsWith('.html')) {
+              renderedRoute.outputPath = path.join(__dirname, 'dist', renderedRoute.route)
+            }
+            return renderedRoute
+          },
           renderer: new Renderer({
             renderAfterDocumentEvent: 'render-event',
+            headless: true,
           }),
         })
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3313,11 +3313,6 @@ deepmerge@^1.5.2:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
   integrity sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==
 
-deepmerge@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
-  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
-
 default-gateway@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-4.2.0.tgz#167104c7500c2115f6dd69b0a536bb8ed720552b"
@@ -9291,13 +9286,6 @@ vue-loader@^15.9.2:
     loader-utils "^1.1.0"
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
-
-vue-meta@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/vue-meta/-/vue-meta-2.4.0.tgz#a419fb4b4135ce965dab32ec641d1989c2ee4845"
-  integrity sha512-XEeZUmlVeODclAjCNpWDnjgw+t3WA6gdzs6ENoIAgwO1J1d5p1tezDhtteLUFwcaQaTtayRrsx7GL6oXp/m2Jw==
-  dependencies:
-    deepmerge "^4.2.2"
 
 vue-router@^4.0.0-0:
   version "4.0.11"


### PR DESCRIPTION
# Description

The main reason why you can't render all routes is you forgot to add a slash (`/`) in `vue.config.js`. (Addressed in 4326dea)

But there's still have other things cause you can't render.

- you used an unknown plugin `vue-meta`, I don't know why you use it, and also you write the wrong code in `main.js` for module usage. (Addressed in 908b321)
  - Suggest see the documentation here https://v3.vuejs.org/api/application-api.html#use
- `dispatchEvent` can be moved to `onMounted` callback function. (Addressed in a10a5be)
- render routes need to contain both `/xxx` and `/xxx/` case. (Addressed in 6f5745f)
- `PrerenderSPA` plugin config is incomplete. (Addressed in 6f5745f)
  - Should add `headless: true` to close the render debug mode
  - Should add `postProcess` to let all rendered routes become a single `html` file in an isolated folder.
  - And I also help you add split-chunk and max-chunk-size config.
  - Suggest see the documentation here https://github.com/chrisvfritz/prerender-spa-plugin#readme